### PR TITLE
Fix import paths in gtk-extensions/gotk3/gotk3.go

### DIFF
--- a/gtk-extensions/gotk3/gotk3.go
+++ b/gtk-extensions/gotk3/gotk3.go
@@ -6,7 +6,7 @@ package gotk3
 //#include <libappindicator/app-indicator.h>
 import "C"
 import "unsafe"
-import "github.com/conformal/gotk3/gtk"
+import "github.com/gotk3/gotk3/gtk"
 import "github.com/doxxan/appindicator"
 
 type AppIndicatorGotk3 struct {

--- a/gtk-extensions/gotk3/gotk3.go
+++ b/gtk-extensions/gotk3/gotk3.go
@@ -7,7 +7,7 @@ package gotk3
 import "C"
 import "unsafe"
 import "github.com/gotk3/gotk3/gtk"
-import "github.com/doxxan/appindicator"
+import "github.com/perlw/appindicator"
 
 type AppIndicatorGotk3 struct {
 	appindicator.AppIndicator


### PR DESCRIPTION
It seems that the `gotk3` development has moved to its own org in github: `gotk3/gotk3` and `doxxan/appindicator` redirects to `perl/appindicator`.
